### PR TITLE
AI integration with Avante and MCP Hub

### DIFF
--- a/dot_config/nvim/lua/plugins/ai/avante.lua
+++ b/dot_config/nvim/lua/plugins/ai/avante.lua
@@ -1,0 +1,33 @@
+
+return {
+	"yetone/avante.nvim",
+	build = "make",
+	event = "VeryLazy",
+	version = false, -- Never set this value to "*"! Never!
+	---@module 'avante'
+	---@type avante.Config
+	opts = {
+		provider = "copilot",
+	},
+	dependencies = {
+		"nvim-lua/plenary.nvim",
+		"MunifTanjim/nui.nvim",
+		--- The below dependencies are optional,
+		-- "echasnovski/mini.pick", -- for file_selector provider mini.pick
+		"nvim-telescope/telescope.nvim", -- for file_selector provider telescope
+		-- "ibhagwan/fzf-lua", -- for file_selector provider fzf
+		"hrsh7th/nvim-cmp", -- autocompletion for avante commands and mentions
+		"stevearc/dressing.nvim", -- for input provider dressing
+		-- "folke/snacks.nvim", -- for input provider snacks
+		"nvim-tree/nvim-web-devicons", -- or echasnovski/mini.icons
+		"zbirenbaum/copilot.lua", -- for providers='copilot'
+		{
+			-- Make sure to set this up properly if you have lazy=true
+			"MeanderingProgrammer/render-markdown.nvim",
+			opts = {
+				file_types = { "markdown", "Avante" },
+			},
+			ft = { "markdown", "Avante" },
+		},
+	},
+}

--- a/dot_config/nvim/lua/plugins/ai/avante.lua
+++ b/dot_config/nvim/lua/plugins/ai/avante.lua
@@ -1,4 +1,3 @@
-
 return {
 	"yetone/avante.nvim",
 	build = "make",
@@ -30,4 +29,21 @@ return {
 			ft = { "markdown", "Avante" },
 		},
 	},
+	config = function(_, opts)
+		require("avante").setup({
+			-- The 'system_prompt' as function ensures LLM always has latest MCP server state.
+			-- This is evaluated for every message, even in existing chats.
+			system_prompt = function()
+				local hub = require("mcphub").get_hub_instance()
+				return hub and hub:get_active_servers_prompt() or ""
+			end,
+
+			-- Using function prevents requiring mcphub before it's loaded
+			custom_tools = function()
+				return {
+					require("mcphub.extensions.avante").mcp_tool(),
+				}
+			end,
+		})
+	end,
 }

--- a/dot_config/nvim/lua/plugins/ai/avante.lua
+++ b/dot_config/nvim/lua/plugins/ai/avante.lua
@@ -1,8 +1,9 @@
+-- Provides AI-assisted coding, editing, and chat features.
 return {
 	"yetone/avante.nvim",
 	build = "make",
 	event = "VeryLazy",
-	version = false, -- Never set this value to "*"! Never!
+	version = false,
 	---@module 'avante'
 	---@type avante.Config
 	opts = {
@@ -11,17 +12,15 @@ return {
 	dependencies = {
 		"nvim-lua/plenary.nvim",
 		"MunifTanjim/nui.nvim",
-		--- The below dependencies are optional,
-		-- "echasnovski/mini.pick", -- for file_selector provider mini.pick
-		"nvim-telescope/telescope.nvim", -- for file_selector provider telescope
-		-- "ibhagwan/fzf-lua", -- for file_selector provider fzf
-		"hrsh7th/nvim-cmp", -- autocompletion for avante commands and mentions
-		"stevearc/dressing.nvim", -- for input provider dressing
-		-- "folke/snacks.nvim", -- for input provider snacks
-		"nvim-tree/nvim-web-devicons", -- or echasnovski/mini.icons
-		"zbirenbaum/copilot.lua", -- for providers='copilot'
+
+		--- The optional dependencies.
+		"nvim-telescope/telescope.nvim", -- File selector.
+		"hrsh7th/nvim-cmp", -- Autocompletion for avante commands and mentions,
+		"stevearc/dressing.nvim", -- UI for user input prompts and dialogs.
+		"nvim-tree/nvim-web-devicons", -- Icons for UI elements.
+		"zbirenbaum/copilot.lua", -- Enables GitHub Copilot as a provider for Avante.
 		{
-			-- Make sure to set this up properly if you have lazy=true
+			-- Avante responses are formatted in Markdown.
 			"MeanderingProgrammer/render-markdown.nvim",
 			opts = {
 				file_types = { "markdown", "Avante" },

--- a/dot_config/nvim/lua/plugins/ai/copilot.lua
+++ b/dot_config/nvim/lua/plugins/ai/copilot.lua
@@ -1,0 +1,13 @@
+-- Integrates gitHub copilot into Neovim, enabling AI-powered code completions.
+return {
+  "zbirenbaum/copilot.lua",
+  event = "InsertEnter",
+  config = function()
+    require("copilot").setup({
+      -- It is recommended to disable copilot.lua's suggestion and panel modules,
+      -- as they can interfere with completions properly appearing in copilot-cmp.
+      suggestion = { enabled = false },
+      panel = { enabled = false },
+    })
+  end,
+}

--- a/dot_config/nvim/lua/plugins/ai/copilot_cmp.lua
+++ b/dot_config/nvim/lua/plugins/ai/copilot_cmp.lua
@@ -1,0 +1,10 @@
+-- GitHub Copilot source for nvim-cmp, enabling AI-powered completions.
+return {
+  "zbirenbaum/copilot-cmp",
+  dependencies = { "zbirenbaum/copilot.lua" },
+  config = function()
+    require("copilot_cmp").setup({
+      debug = true,
+    })
+  end,
+}

--- a/dot_config/nvim/lua/plugins/ai/init.lua
+++ b/dot_config/nvim/lua/plugins/ai/init.lua
@@ -1,5 +1,6 @@
 return {
   require("plugins.ai.copilot"),
   require("plugins.ai.copilot_cmp"),
+  require("plugins.ai.mcp_hub"),
   require("plugins.ai.avante"),
 }

--- a/dot_config/nvim/lua/plugins/ai/init.lua
+++ b/dot_config/nvim/lua/plugins/ai/init.lua
@@ -1,0 +1,5 @@
+return {
+  require("plugins.ai.copilot"),
+  require("plugins.ai.copilot_cmp"),
+  require("plugins.ai.avante"),
+}

--- a/dot_config/nvim/lua/plugins/ai/mcp_hub.lua
+++ b/dot_config/nvim/lua/plugins/ai/mcp_hub.lua
@@ -1,0 +1,11 @@
+-- Integrates MCP Hub into Neovim, enabling connection to Model Context Protocol servers/tools.
+return {
+	"ravitemer/mcphub.nvim",
+	dependencies = {
+		"nvim-lua/plenary.nvim",
+	},
+	build = "npm install -g mcp-hub@latest", -- Installs `mcp-hub` node binary globally.
+	config = function()
+		require("mcphub").setup()
+	end,
+}


### PR DESCRIPTION
## Summary
This PR integrates AI-assisted coding capabilities into Neovim by setting up as the AI interaction layer and connecting it with MCP Hub for multi-provider support. It leverages the existing nvim-cmp setup to ensure smooth inline completions and maintains compatibility with the current LSP configuration.

## Changes
- Installed and configured Avante.nvim as the core AI interaction layer.
- Connected Avante to GitHub Copilot as the initial AI provider.
- Added MCP Hub integration to enable access to multiple AI backends (e.g., Copilot, Ollama, custom MCP servers).
- Updated dependencies and comments in plugin configs for clarity and maintainability.
- Verified compatibility with nvim-cmp and existing keymaps.
- Added support for rendering Markdown in Avante responses (render-markdown.nvim).

## Tasks
- [x] Install and configure Avante.nvim.
- [x] Connect Avante to GitHub Copilot (default provider).
- [x] Add MCP Hub integration for multi-provider AI access.
- [x] Ensure compatibility with nvim-cmp + LSP keymaps.
- [x] Test inline code completions.
- [x] Test AI chat commands and Markdown rendering.
